### PR TITLE
UefiPayloadPkg/SmBusDxe: Remove PciIo Dependency

### DIFF
--- a/UefiPayloadPkg/SmbusDxe/SMBusi801Dxe.h
+++ b/UefiPayloadPkg/SmbusDxe/SMBusi801Dxe.h
@@ -12,7 +12,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <IndustryStandard/Pci.h>
 #include <IndustryStandard/Pci22.h>
-#include <Protocol/PciIo.h>
 #include <Protocol/SmbusHc.h>
 
 #endif

--- a/UefiPayloadPkg/SmbusDxe/SMBusi801Dxe.inf
+++ b/UefiPayloadPkg/SmbusDxe/SMBusi801Dxe.inf
@@ -36,10 +36,10 @@
   IoLib
   UefiLib
   TimerLib
-
-[Depex]
-  gEfiPciIoProtocolGuid
+  PciExpressLib
 
 [Protocols]
   gEfiSmbusHcProtocolGuid                       ## PRODUCES
-  gEfiPciIoProtocolGuid                         ## COMSUMES
+
+[Depex]
+  TRUE


### PR DESCRIPTION
Remote PciIo Protocol Dependency and replace this with PciExpressLib.
THe Dxe can now be loaded before e.g. Secure Boot as it has lesser
dependencies.

Signed-off-by: Christian Walter <christian.walter@9elements.com>