### PR TITLE
UefiPayloadPkg: Add PEI SMMStore support

### DIFF
--- a/UefiPayloadPkg/BlSMMStoreDxe/BlSMMStoreDxe.c
+++ b/UefiPayloadPkg/BlSMMStoreDxe/BlSMMStoreDxe.c
@@ -218,14 +218,6 @@ BlSMMSTOREInitialise (
     return Status;
   }
 
-  // Update PCDs for Variable/RuntimeDxe
-  PcdSet32S (PcdFlashNvStorageVariableBase,
-      PcdGet32 (PcdFlashNvStorageVariableBase) + SMMStoreInfoHob->MmioAddress);
-  PcdSet32S (PcdFlashNvStorageFtwWorkingBase,
-      PcdGet32 (PcdFlashNvStorageFtwWorkingBase) + SMMStoreInfoHob->MmioAddress);
-  PcdSet32S (PcdFlashNvStorageFtwSpareBase,
-      PcdGet32 (PcdFlashNvStorageFtwSpareBase) + SMMStoreInfoHob->MmioAddress);
-
   mSMMStoreInstance = AllocateRuntimePool (sizeof(SMMSTORE_INSTANCE*));
   if (!mSMMStoreInstance) {
     DEBUG((EFI_D_ERROR, "%a: Out of resources\n", __FUNCTION__));

--- a/UefiPayloadPkg/BlSMMStorePei/BlSMMStorePei.c
+++ b/UefiPayloadPkg/BlSMMStorePei/BlSMMStorePei.c
@@ -1,0 +1,64 @@
+/** @file  BlSMMStorePei.c
+
+  Copyright (c) 2020, 9elements Agency GmbH<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "BlSMMStorePei.h"
+
+/**
+  This is the entrypoint of PEIM
+
+  @param  FileHandle  Handle of the file being invoked.
+  @param  PeiServices Describes the list of possible PEI Services.
+
+  @retval EFI_SUCCESS if it completed successfully.
+**/
+EFI_STATUS
+EFIAPI
+BlSMMSTOREEntryPoint (
+  IN       EFI_PEI_FILE_HANDLE     FileHandle,
+  IN CONST EFI_PEI_SERVICES        **PeiServices
+  )
+{
+  VOID                                    *GuidHob;
+  SMMSTORE_INFO                           SMMStoreInfo;
+
+  if (PcdGetBool (PcdEmuVariableNvModeEnable)) {
+    DEBUG ((DEBUG_WARN, "Variable emulation is active! Skipping driver init.\n"));
+    return EFI_SUCCESS;
+  }
+
+  //
+  // Find the SMMSTORE information guid hob
+  //
+  GuidHob = GetFirstGuidHob (&gEfiSMMSTOREInfoHobGuid);
+  if (GuidHob == NULL) {
+    DEBUG ((DEBUG_WARN, "SMMSTORE not supported! Skipping driver init.\n"));
+    PcdSetBoolS (PcdEmuVariableNvModeEnable, TRUE);
+    return EFI_SUCCESS;
+  }
+
+  CopyMem(&SMMStoreInfo, GET_GUID_HOB_DATA (GuidHob), GET_GUID_HOB_DATA_SIZE(GuidHob));
+
+  if (!SMMStoreInfo.MmioAddress ||
+      !SMMStoreInfo.ComBuffer ||
+      !SMMStoreInfo.BlockSize ||
+      !SMMStoreInfo.NumBlocks) {
+    DEBUG((EFI_D_ERROR, "%a: Invalid data in SMMStore Info hob\n", __FUNCTION__));
+    PcdSetBoolS (PcdEmuVariableNvModeEnable, TRUE);
+    return EFI_WRITE_PROTECTED;
+  }
+
+  // Update PCDs for Variable/RuntimeDxe
+  PcdSet32S (PcdFlashNvStorageVariableBase,
+      PcdGet32 (PcdFlashNvStorageVariableBase) + SMMStoreInfo.MmioAddress);
+  PcdSet32S (PcdFlashNvStorageFtwWorkingBase,
+      PcdGet32 (PcdFlashNvStorageFtwWorkingBase) + SMMStoreInfo.MmioAddress);
+  PcdSet32S (PcdFlashNvStorageFtwSpareBase,
+      PcdGet32 (PcdFlashNvStorageFtwSpareBase) + SMMStoreInfo.MmioAddress);
+
+  return EFI_SUCCESS;
+}

--- a/UefiPayloadPkg/BlSMMStorePei/BlSMMStorePei.h
+++ b/UefiPayloadPkg/BlSMMStorePei/BlSMMStorePei.h
@@ -1,0 +1,24 @@
+/** @file  BlSMMStorePei.h
+
+  Copyright (c) 2020, 9elements Agency GmbH<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __COREBOOT_SMM_STORE_PEI_H__
+#define __COREBOOT_SMM_STORE_PEI_H__
+
+
+#include <Base.h>
+#include <PiPei.h>
+#include <Library/PeimEntryPoint.h>
+#include <Library/PeiServicesLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PcdLib.h>
+#include <Library/SMMStoreLib.h>
+#include <Library/HobLib.h>
+#include <Protocol/FirmwareVolumeBlock.h>
+
+#endif /* __COREBOOT_SMM_STORE_PEI_H__ */

--- a/UefiPayloadPkg/BlSMMStorePei/BlSMMStorePei.inf
+++ b/UefiPayloadPkg/BlSMMStorePei/BlSMMStorePei.inf
@@ -1,0 +1,54 @@
+#/** @file
+#
+#  Component description file for SMMSTORE module
+#
+#  Copyright (c) 2020, 9elements Agency GmbH<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#**/
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = UefiPayloadBlSMMStorePei
+  FILE_GUID                      = 78491794-1228-4591-BB1E-D6C4063BCFDB
+  MODULE_TYPE                    = PEIM
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = BlSMMSTOREEntryPoint
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources.common]
+  BlSMMStorePei.h
+  BlSMMStorePei.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  UefiPayloadPkg/UefiPayloadPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  HobLib
+  PcdLib
+  PeimEntryPoint
+
+[Guids]
+  gEfiSMMSTOREInfoHobGuid
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableSize
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingSize
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareBase
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareSize
+  gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvModeEnable
+
+[Depex]
+  gEfiPeiMasterBootModePpiGuid

--- a/UefiPayloadPkg/UefiPayloadPkg.fdf
+++ b/UefiPayloadPkg/UefiPayloadPkg.fdf
@@ -51,6 +51,8 @@ INF MdeModulePkg/Universal/StatusCodeHandler/Pei/StatusCodeHandlerPei.inf
 INF UefiPayloadPkg/BlSupportPei/BlSupportPei.inf
 INF MdeModulePkg/Core/DxeIplPeim/DxeIpl.inf
 INF UefiPayloadPkg/NullVariable/NullVariablePei.inf
+INF UefiPayloadPkg/BlSMMStorePei/BlSMMStorePei.inf
+INF MdeModulePkg/Universal/FaultTolerantWritePei/FaultTolerantWritePei.inf
 
 !if $(TPM_ENABLE) == TRUE
 INF  SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf

--- a/UefiPayloadPkg/UefiPayloadPkgIa32.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkgIa32.dsc
@@ -469,8 +469,10 @@
   MdeModulePkg/Universal/StatusCodeHandler/Pei/StatusCodeHandlerPei.inf
 
   UefiPayloadPkg/BlSupportPei/BlSupportPei.inf
+  UefiPayloadPkg/BlSMMStorePei/BlSMMStorePei.inf
   MdeModulePkg/Core/DxeIplPeim/DxeIpl.inf
   UefiPayloadPkg/NullVariable/NullVariablePei.inf
+  MdeModulePkg/Universal/FaultTolerantWritePei/FaultTolerantWritePei.inf
 
 !if $(TPM_ENABLE) == TRUE
   SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf

--- a/UefiPayloadPkg/UefiPayloadPkgIa32X64.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkgIa32X64.dsc
@@ -480,8 +480,11 @@
   MdeModulePkg/Universal/StatusCodeHandler/Pei/StatusCodeHandlerPei.inf
 
   UefiPayloadPkg/BlSupportPei/BlSupportPei.inf
+  UefiPayloadPkg/BlSMMStorePei/BlSMMStorePei.inf
+
   MdeModulePkg/Core/DxeIplPeim/DxeIpl.inf
   UefiPayloadPkg/NullVariable/NullVariablePei.inf
+  MdeModulePkg/Universal/FaultTolerantWritePei/FaultTolerantWritePei.inf
 
 !if $(TPM_ENABLE) == TRUE
   SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
@@ -496,6 +499,9 @@
       NULL|SecurityPkg/Library/HashInstanceLibSm3/HashInstanceLibSm3.inf
   }
 !endif
+
+  # SMMSTORE
+  #
 
 [Components.X64]
   #


### PR DESCRIPTION
Add support for SMMSTORE in PEI and add FaultTolerantWritePei to the list of
modules, which detects aborts while doing FTW on the previous boot.

Signed-off-by: Patrick Rudolph <patrick.rudolph@9elements.com>